### PR TITLE
fix: project listing arrangement

### DIFF
--- a/app/(www)/page.tsx
+++ b/app/(www)/page.tsx
@@ -106,7 +106,7 @@ export default async function IndexPage() {
           <p className="leading-normal text-muted-foreground sm:text-xl sm:leading-8">
             I like to engineer solutions that make a difference. Whether it&apos;s crafting problem-solving applications for businesses, creating tools that streamline my workflow or just hacking around with some ideas, innovation drives me. Here&apos;s a curated project collection, ranging from empowering business solutions to personal hacks that have either aided my learning or transformed my productivity:
           </p>
-          <div className="flex flex-wrap justify-between">
+          <div className="flex flex-wrap justify-between md:justify-normal md:gap-3">
             {projects.map((p, i) => (
               <ProjectCard key={i} {...p} />
             ))}


### PR DESCRIPTION
This PR fixes the CSS on the project listing section on the homepage where space is completely widened when the amount of item on a column is 2.

### Screenshots

**Before**

![image](https://github.com/user-attachments/assets/0b7185f8-6aff-46ec-8360-3d1023ee93a4)


**After**

![image](https://github.com/user-attachments/assets/8e75c79e-0b67-40a6-acb0-0f4a18c3c256)
